### PR TITLE
Select search

### DIFF
--- a/packages/ember-select/addon/components/tpk-select.ts
+++ b/packages/ember-select/addon/components/tpk-select.ts
@@ -178,10 +178,8 @@ export default class TpkSelect<
     const res = this.activeChildIndex + value;
 
     if (res > this.args.options.length - 1) {
-      this.activeChildIndex = 0;
-    } else if (res < 0) {
       this.activeChildIndex = this.args.options.length - 1;
-    } else if (res === 0) {
+    } else if (res <= 0) {
       this.activeChildIndex = 0;
     } else {
       this.activeChildIndex = res;

--- a/packages/ember-select/tests/integration/components/tpk-select-search-test.ts
+++ b/packages/ember-select/tests/integration/components/tpk-select-search-test.ts
@@ -67,7 +67,6 @@ module('Integration | Component | tpk-select-search', function (hooks) {
     await tpkSelectSearch.button.click();
     assert.strictEqual(tpkSelectSearch.button.isExpanded, 'true');
     assert.strictEqual(tpkSelectSearch.isOpen, 'true');
-    
     await tpkSelectSearch.input.fillIn(fillValue);
     await tpkSelectSearch.button.enter();
 

--- a/packages/ember-select/tests/integration/components/tpk-select-search-test.ts
+++ b/packages/ember-select/tests/integration/components/tpk-select-search-test.ts
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import tpkSelectSearch from 'dummy/tests/pages/tpk-select-search';
 
-module('Integration | Component | tpk-select', function (hooks) {
+module('Integration | Component | tpk-select-search', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -67,12 +67,12 @@ module('Integration | Component | tpk-select', function (hooks) {
     await tpkSelectSearch.button.click();
     assert.strictEqual(tpkSelectSearch.button.isExpanded, 'true');
     assert.strictEqual(tpkSelectSearch.isOpen, 'true');
-
+    
     await tpkSelectSearch.input.fillIn(fillValue);
     await tpkSelectSearch.button.enter();
 
     assert.strictEqual(tpkSelectSearch.button.isExpanded, 'false');
     assert.strictEqual(tpkSelectSearch.isOpen, 'false');
-    assert.strictEqual(tpkSelectSearch.button.text, fillValue);
+    assert.strictEqual(tpkSelectSearch.input.value, fillValue);
   });
 });

--- a/packages/ember-select/tests/integration/components/tpk-select-test.ts
+++ b/packages/ember-select/tests/integration/components/tpk-select-test.ts
@@ -341,13 +341,12 @@ module('Integration | Component | tpk-select', function (hooks) {
     await tpkSelect.button.click();
     assert.strictEqual(tpkSelect.button.isExpanded, 'true');
     assert.strictEqual(tpkSelect.isOpen, 'true');
-
+    
     await tpkSelect.button.arrowDown();
     assert.strictEqual(tpkSelect.listbox.options[0].hasFocus, 'true');
     await tpkSelect.button.arrowDown();
     assert.strictEqual(tpkSelect.listbox.options[1].hasFocus, 'true');
     assert.strictEqual(tpkSelect.button.isExpanded, 'true');
-    assert.strictEqual(tpkSelect.isOpen, 'true');
 
     for (let index = 0; index < backendArray.length; index++) {
       await tpkSelect.button.arrowDown();

--- a/packages/ember-select/tests/integration/components/tpk-select-test.ts
+++ b/packages/ember-select/tests/integration/components/tpk-select-test.ts
@@ -346,7 +346,6 @@ module('Integration | Component | tpk-select', function (hooks) {
     assert.strictEqual(tpkSelect.listbox.options[0].hasFocus, 'true');
     await tpkSelect.button.arrowDown();
     assert.strictEqual(tpkSelect.listbox.options[1].hasFocus, 'true');
-    assert.strictEqual(tpkSelect.button.isExpanded, 'true');
 
     for (let index = 0; index < backendArray.length; index++) {
       await tpkSelect.button.arrowDown();

--- a/packages/ember-select/tests/integration/components/tpk-select-test.ts
+++ b/packages/ember-select/tests/integration/components/tpk-select-test.ts
@@ -341,7 +341,6 @@ module('Integration | Component | tpk-select', function (hooks) {
     await tpkSelect.button.click();
     assert.strictEqual(tpkSelect.button.isExpanded, 'true');
     assert.strictEqual(tpkSelect.isOpen, 'true');
-    
     await tpkSelect.button.arrowDown();
     assert.strictEqual(tpkSelect.listbox.options[0].hasFocus, 'true');
     await tpkSelect.button.arrowDown();


### PR DESCRIPTION
J'ai adapté le comportement du select search ( dans des commits du main :x ) 
Je me suis basé sur le comportement W3C
Dans cette PR, j'ai adapté mes changements car j'appliquais le comportement du tpk-select-search au tpk-select. Ce qui n'était pas le cas. 